### PR TITLE
Add serviceAccount option to bin/register-service-account

### DIFF
--- a/bin/register-service-account
+++ b/bin/register-service-account
@@ -5,7 +5,7 @@
 # This script expects gcloud SDK is installed and authenticated as an account
 # having the roles/admin on the target GCP project.
 
-set -euo pipefail -o posix
+set -eo pipefail -o posix
 
 PROGNAME=$(basename $0)
 
@@ -13,12 +13,13 @@ usage() {
   echo "Usage: $PROGNAME [OPTIONS] REPONAME"
   echo
   echo "Arguments:"
-  echo " REPONAME               Target GitHub repository name."
+  echo " REPONAME                      Target GitHub repository name."
   echo
   echo "Options:"
-  echo " -h, --help             Show this help."
-  echo " -o, --orgname ORGNAME  GitHub organization name. (Default: flywheel-jp)"
-  echo " -p, --project PROJECT  GCP project name. (Default: flywheel-mouseion)"
+  echo " -h, --help                    Show this help."
+  echo " -o, --orgname        ORGNAME  GitHub organization name. (Default: flywheel-jp)"
+  echo " -p, --project        PROJECT  GCP project name. (Default: flywheel-mouseion)"
+  echo " -s, --serviceAccount NAME     Service account name. Use this if REPONAME is shorter than 6 chars."
   echo
   exit 1
 }
@@ -43,6 +44,13 @@ do
       project=$2
       shift 2
       ;;
+    -s | --serviceAccount)
+      if [[ -z "$2" ]] || [[ "$2" =~ ^-+ ]]; then
+        usage
+      fi
+      serviceAccount=$2
+      shift 2
+      ;;
     *)
       if [[ ! -z "$1" ]] && [[ ! "$1" =~ ^-+ ]]; then
         param+=( "$1" )
@@ -60,7 +68,8 @@ fi
 REPONAME="$param"
 PROJECT="${project:-flywheel-mouseion}"
 ORGNAME="${orgname:-flywheel-jp}"
-EMAIL="${REPONAME}@${PROJECT}.iam.gserviceaccount.com"
+SERVICE_ACCOUNT="${serviceAccount:-$REPONAME}"
+EMAIL="${SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com"
 KEY="tmp/${REPONAME}.json"
 
 if [ -z "$REPONAME" ] ; then
@@ -69,7 +78,7 @@ if [ -z "$REPONAME" ] ; then
 fi
 
 echo "Create a service account"
-gcloud iam service-accounts create "$REPONAME" \
+gcloud iam service-accounts create "${SERVICE_ACCOUNT}" \
   --display-name="${REPONAME}-deploy-agent" \
   --description="Service account for ${ORGNAME}/${REPONAME}" \
   --project="$PROJECT"


### PR DESCRIPTION
## What
Add `-s` `--serviceAccount` option to bin/register-service-account script. Use this option if REPONAME is shorter than 6 chars.

### Usage

```
bin/register-service-account -s foo-deploy-agent foo
```